### PR TITLE
Extended template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin/.libs/
 bin/Makefile
 bin/jfd-anon
 bin/joy
+bin/joy_static
 bin/joy-anon
 bin/joy_api_test
 bin/joy_api_test2
@@ -27,3 +28,6 @@ safe_c_stub/src/.dirstamp
 src/.deps/
 src/.dirstamp
 stamp-h1
+.idea/
+cmake-build-debug/
+CMakeLists.txt

--- a/src/include/ipfix.h
+++ b/src/include/ipfix.h
@@ -419,8 +419,8 @@ typedef struct ipfix_exporter_data_idp_ {
 } ipfix_exporter_data_idp_t;
 
 
-// 12 * 7 for six basic lists
-#define SIZE_IPFIX_DATA_EXTENDED 84 + SIZE_IPFIX_DATA_SIMPLE
+// 12 * 7 for basic lists + 3 for sni
+#define SIZE_IPFIX_DATA_EXTENDED 87 + SIZE_IPFIX_DATA_SIMPLE
 
 typedef struct ipfix_exporter_data_extended_ {
     uint32_t source_ipv4_address;
@@ -430,6 +430,7 @@ typedef struct ipfix_exporter_data_extended_ {
     uint8_t protocol_identifier;
     uint64_t flow_start_microseconds;
     uint64_t flow_end_microseconds;
+    ipfix_variable_field_t tls_sni;
     ipfix_basic_list_field_t packet_lengths;
     ipfix_basic_list_field_t packet_directions;
     ipfix_basic_list_field_t packet_times;
@@ -656,7 +657,8 @@ enum ipfix_entities {
   IPFIX_PACKET_LENGTHS =                            44962,
   IPFIX_PACKET_TIMES =                              44963,
   IPFIX_PACKET_FLAGS =                              44964,
-  IPFIX_PACKET_DIRECTIONS =                         44965
+  IPFIX_PACKET_DIRECTIONS =                         44965,
+  IPFIX_TLS_SNI =                                   33106, /* 32768 + 338*/
 };
 
 

--- a/src/include/ipfix.h
+++ b/src/include/ipfix.h
@@ -602,6 +602,8 @@ enum ipfix_set_type {
   IPFIX_OPTION_SET =                                3,
 };
 
+#define CESNET_PEN 8057
+#define FLOWMON_PEN 39499
 
 /*
  * @brief Enumeration representing IPFIX field entities.
@@ -654,11 +656,15 @@ enum ipfix_entities {
   IPFIX_TLS_HANDSHAKE_TYPES =                       44959,
   IPFIX_TLS_EXTENSION_LENGTHS =                     44960,
   IPFIX_TLS_EXTENSION_TYPES =                       44961,
-  IPFIX_PACKET_LENGTHS =                            44962,
-  IPFIX_PACKET_TIMES =                              44963,
-  IPFIX_PACKET_FLAGS =                              44964,
-  IPFIX_PACKET_DIRECTIONS =                         44965,
-  IPFIX_TLS_SNI =                                   33106, /* 32768 + 338*/
+  /* CESNET PPI elements*/
+  IPFIX_PPI_TLS_REC_LENGTHS =                       33778, /* 32768 + 1010*/
+  IPFIX_PPI_TLS_REC_TIMES =                         33779,
+  IPFIX_PPI_TLS_CONTENT_TYPES =                     33780,
+  IPFIX_PPI_PKT_LENGTHS =                           33781,
+  IPFIX_PPI_PKT_TIMES =                             33782,
+  IPFIX_PPI_PKT_FLAGS =                             33783,
+  IPFIX_PPI_PKT_DIRECTIONS =                        33784,
+  IPFIX_TLS_SNI =                                   33106, /* 32768 + flowmon element tls_sni 338*/
 };
 
 

--- a/src/include/ipfix.h
+++ b/src/include/ipfix.h
@@ -277,6 +277,8 @@ typedef struct ipfix_basic_list_hdr_ {
 
 #else
 
+#define BASIC_LIST_HEADER_SIZE 9
+
 typedef struct __attribute__((__packed__)) ipfix_basic_list_hdr_ {
     uint8_t semantic;
     uint16_t field_id;
@@ -336,7 +338,8 @@ typedef struct ipfix_collector_ {
 typedef enum ipfix_template_type_ {
   IPFIX_RESERVED_TEMPLATE =                          0,
   IPFIX_SIMPLE_TEMPLATE =                            1,
-  IPFIX_IDP_TEMPLATE =                               2
+  IPFIX_IDP_TEMPLATE =                               2,
+  IPFIX_EXTENDED_TEMPLATE =                          3
 } ipfix_template_type_e;
 
 
@@ -374,6 +377,17 @@ typedef struct ipfix_variable_field_ {
     unsigned char *info;
 } ipfix_variable_field_t;
 
+
+#define MIN_SIZE_BASIC_LIST_FIELD 3 + BASIC_LIST_HEADER_SIZE
+
+typedef struct ipfix_basic_list_field_ {
+    uint8_t flag;
+    uint16_t length;
+    ipfix_basic_list_hdr_t header;
+    unsigned char *content;
+} ipfix_basic_list_field_t;
+
+
 #define SIZE_IPFIX_DATA_SIMPLE 29
 
 typedef struct ipfix_exporter_data_simple_ {
@@ -405,6 +419,22 @@ typedef struct ipfix_exporter_data_idp_ {
 } ipfix_exporter_data_idp_t;
 
 
+#define SIZE_IPFIX_DATA_EXTENDED 36 + SIZE_IPFIX_DATA_SIMPLE
+
+typedef struct ipfix_exporter_data_extended_ {
+    uint32_t source_ipv4_address;
+    uint32_t destination_ipv4_address;
+    uint16_t source_transport_port;
+    uint16_t destination_transport_port;
+    uint8_t protocol_identifier;
+    uint64_t flow_start_microseconds;
+    uint64_t flow_end_microseconds;
+    ipfix_basic_list_field_t tls_record_lengths;
+    ipfix_basic_list_field_t tls_record_times;
+    ipfix_basic_list_field_t tls_record_types;
+} ipfix_exporter_data_extended_t;
+
+
 /*
  * @brief Structure representing an IPFIX Exporter Data record.
  */
@@ -412,6 +442,7 @@ typedef struct ipfix_exporter_data_ {
   union {
     ipfix_exporter_data_simple_t simple;
     ipfix_exporter_data_idp_t idp_record;
+    ipfix_exporter_data_extended_t extended_record;
   } record;
   ipfix_template_type_e type;
   uint16_t length; /**< total length the data record */

--- a/src/include/ipfix.h
+++ b/src/include/ipfix.h
@@ -419,7 +419,8 @@ typedef struct ipfix_exporter_data_idp_ {
 } ipfix_exporter_data_idp_t;
 
 
-#define SIZE_IPFIX_DATA_EXTENDED 36 + SIZE_IPFIX_DATA_SIMPLE
+// 12 * 7 for six basic lists
+#define SIZE_IPFIX_DATA_EXTENDED 84 + SIZE_IPFIX_DATA_SIMPLE
 
 typedef struct ipfix_exporter_data_extended_ {
     uint32_t source_ipv4_address;
@@ -429,6 +430,10 @@ typedef struct ipfix_exporter_data_extended_ {
     uint8_t protocol_identifier;
     uint64_t flow_start_microseconds;
     uint64_t flow_end_microseconds;
+    ipfix_basic_list_field_t packet_lengths;
+    ipfix_basic_list_field_t packet_directions;
+    ipfix_basic_list_field_t packet_times;
+    ipfix_basic_list_field_t packet_flags;
     ipfix_basic_list_field_t tls_record_lengths;
     ipfix_basic_list_field_t tls_record_times;
     ipfix_basic_list_field_t tls_record_types;
@@ -541,7 +546,7 @@ typedef struct ipfix_exporter_ {
 #endif
 
 #if CPU_IS_BIG_ENDIAN
-# define bytes_to_u32(bytes) (bytes[0] << 24) + (bytes[1] << 16) + (bytes[2] << 8) + bytes[3] 
+# define bytes_to_u32(bytes) (bytes[0] << 24) + (bytes[1] << 16) + (bytes[2] << 8) + bytes[3]
 #else
 # define bytes_to_u32(bytes) bytes[0] + (bytes[1] << 8) + (bytes[2] << 16) + (bytes[3] << 24)
 #endif
@@ -647,7 +652,11 @@ enum ipfix_entities {
   IPFIX_TLS_CONTENT_TYPES =                         44958,
   IPFIX_TLS_HANDSHAKE_TYPES =                       44959,
   IPFIX_TLS_EXTENSION_LENGTHS =                     44960,
-  IPFIX_TLS_EXTENSION_TYPES =                       44961
+  IPFIX_TLS_EXTENSION_TYPES =                       44961,
+  IPFIX_PACKET_LENGTHS =                            44962,
+  IPFIX_PACKET_TIMES =                              44963,
+  IPFIX_PACKET_FLAGS =                              44964,
+  IPFIX_PACKET_DIRECTIONS =                         44965
 };
 
 

--- a/src/ipfix.c
+++ b/src/ipfix.c
@@ -52,6 +52,7 @@
 #endif
 
 #include <openssl/rand.h>
+#include <ipfix.h>
 #include "safe_lib.h"
 #include "ipfix.h"
 #include "pkt.h"
@@ -3326,7 +3327,7 @@ static unsigned interleave_ppi( const flow_record_t *fr_record,
     uint8_t pkt_flags;
     int16_t pkt_len;
 
-    if (fr_record->twin == NULL || fr_record->ppi->np == 0 || fr_record->twin->ppi->np == 0) {
+    if (fr_record->ppi == NULL || fr_record->twin == NULL || fr_record->twin->ppi == NULL || fr_record->ppi->np == 0 || fr_record->twin->ppi->np == 0) {
         return 0;
     }
 

--- a/src/ipfix.c
+++ b/src/ipfix.c
@@ -1970,10 +1970,10 @@ static uint16_t exporter_template_id = 256;
   ((ipfix_exporter_template_field_t) {a, b, 9})
 
 #define ipfix_exp_template_cesnet_field_macro(a, b) \
-  ((ipfix_exporter_template_field_t) {a, b, 8057})
+  ((ipfix_exporter_template_field_t) {a, b, CESNET_PEN})
 
 #define ipfix_exp_template_flowmon_field_macro(a, b) \
-  ((ipfix_exporter_template_field_t) {a, b, 39499})
+  ((ipfix_exporter_template_field_t) {a, b, FLOWMON_PEN})
 
 /*
  * @brief Allocate heap memory for a sequence of fields.
@@ -3592,39 +3592,39 @@ static ipfix_exporter_data_t *ipfix_exp_create_extended_data_record
 
         packet_count = interleave_ppi(fr_record, &packet_lengths, &packet_times, &packet_flags, &packet_directions);
 
-        /* IPFIX_PACKET_LENGTHS */
+        /* IPFIX_PPI_PKT_LENGTHS */
         data_record->record.extended_record.packet_lengths.flag = 255;
         data_record->record.extended_record.packet_lengths.length = BASIC_LIST_HEADER_SIZE + packet_count * sizeof(int16_t);
-        data_record->record.extended_record.packet_lengths.header.field_id = IPFIX_PACKET_LENGTHS;
+        data_record->record.extended_record.packet_lengths.header.field_id = IPFIX_PPI_PKT_LENGTHS;
         data_record->record.extended_record.packet_lengths.header.element_length = sizeof(int16_t);
-        data_record->record.extended_record.packet_lengths.header.enterprise_num = 9; // CISCO
+        data_record->record.extended_record.packet_lengths.header.enterprise_num = CESNET_PEN;
         data_record->record.extended_record.packet_lengths.header.semantic = 3; // ALL OF
         data_record->record.extended_record.packet_lengths.content = (unsigned char *) packet_lengths;
 
-        /* IPFIX_PACKET_DIRECTIONS*/
+        /* IPFIX_PPI_PKT_DIRECTIONS*/
         data_record->record.extended_record.packet_directions.flag = 255;
         data_record->record.extended_record.packet_directions.length = BASIC_LIST_HEADER_SIZE + packet_count * sizeof(uint8_t);
-        data_record->record.extended_record.packet_directions.header.field_id = IPFIX_PACKET_DIRECTIONS;
+        data_record->record.extended_record.packet_directions.header.field_id = IPFIX_PPI_PKT_DIRECTIONS;
         data_record->record.extended_record.packet_directions.header.element_length = sizeof(char);
-        data_record->record.extended_record.packet_directions.header.enterprise_num = 9;
+        data_record->record.extended_record.packet_directions.header.enterprise_num = CESNET_PEN;
         data_record->record.extended_record.packet_directions.header.semantic = 3;
         data_record->record.extended_record.packet_directions.content = (unsigned char *) packet_directions;
 
-        /* IPFIX_PACKET_TIMES */
+        /* IPFIX_PPI_PKT_TIMES */
         data_record->record.extended_record.packet_times.flag = 255;
         data_record->record.extended_record.packet_times.length = BASIC_LIST_HEADER_SIZE + packet_count * sizeof(uint16_t);
-        data_record->record.extended_record.packet_times.header.field_id = IPFIX_PACKET_TIMES;
+        data_record->record.extended_record.packet_times.header.field_id = IPFIX_PPI_PKT_TIMES;
         data_record->record.extended_record.packet_times.header.element_length = sizeof(uint16_t);
-        data_record->record.extended_record.packet_times.header.enterprise_num = 9;
+        data_record->record.extended_record.packet_times.header.enterprise_num = CESNET_PEN;
         data_record->record.extended_record.packet_times.header.semantic = 3;
         data_record->record.extended_record.packet_times.content = (unsigned char *) packet_times;
 
-        /* IPFIX_PACKET_FLAGS */
+        /* IPFIX_PPI_PKT_FLAGS */
         data_record->record.extended_record.packet_flags.flag = 255;
         data_record->record.extended_record.packet_flags.length = BASIC_LIST_HEADER_SIZE + packet_count * sizeof(uint8_t);
-        data_record->record.extended_record.packet_flags.header.field_id = IPFIX_PACKET_FLAGS;
+        data_record->record.extended_record.packet_flags.header.field_id = IPFIX_PPI_PKT_FLAGS;
         data_record->record.extended_record.packet_flags.header.element_length = sizeof(uint8_t);
-        data_record->record.extended_record.packet_flags.header.enterprise_num = 9;
+        data_record->record.extended_record.packet_flags.header.enterprise_num = CESNET_PEN;
         data_record->record.extended_record.packet_flags.header.semantic = 3;
         data_record->record.extended_record.packet_flags.content = packet_flags;
 
@@ -3633,30 +3633,30 @@ static ipfix_exporter_data_t *ipfix_exp_create_extended_data_record
          */
         tls_record_count = interleave_tls(fr_record, &tls_record_lengths, &tls_record_times, &tls_record_types);
 
-        /* IPFIX_TLS_RECORD_LENGTHS */
+        /* IPFIX_PPI_TLS_REC_LENGTHS */
         data_record->record.extended_record.tls_record_lengths.flag = 255;
         data_record->record.extended_record.tls_record_lengths.length = BASIC_LIST_HEADER_SIZE + tls_record_count * sizeof(int16_t);
-        data_record->record.extended_record.tls_record_lengths.header.field_id = IPFIX_TLS_RECORD_LENGTHS;
+        data_record->record.extended_record.tls_record_lengths.header.field_id = IPFIX_PPI_TLS_REC_LENGTHS;
         data_record->record.extended_record.tls_record_lengths.header.element_length = sizeof(int16_t);
-        data_record->record.extended_record.tls_record_lengths.header.enterprise_num = 9; // CISCO
+        data_record->record.extended_record.tls_record_lengths.header.enterprise_num = CESNET_PEN;
         data_record->record.extended_record.tls_record_lengths.header.semantic = 3; // ALL OF
         data_record->record.extended_record.tls_record_lengths.content = (unsigned char *) tls_record_lengths;
 
-        /* IPFIX_TLS_RECORD_TIMES */
+        /* IPFIX_PPI_TLS_REC_TIMES */
         data_record->record.extended_record.tls_record_times.flag = 255;
         data_record->record.extended_record.tls_record_times.length = BASIC_LIST_HEADER_SIZE + tls_record_count * sizeof(uint16_t);
-        data_record->record.extended_record.tls_record_times.header.field_id = IPFIX_TLS_RECORD_TIMES;
+        data_record->record.extended_record.tls_record_times.header.field_id = IPFIX_PPI_TLS_REC_TIMES;
         data_record->record.extended_record.tls_record_times.header.element_length = sizeof(uint16_t);
-        data_record->record.extended_record.tls_record_times.header.enterprise_num = 9;
+        data_record->record.extended_record.tls_record_times.header.enterprise_num = CESNET_PEN;
         data_record->record.extended_record.tls_record_times.header.semantic = 3;
         data_record->record.extended_record.tls_record_times.content = (unsigned char *) tls_record_times;
 
-        /* IPFIX_TLS_CONTENT_TYPES */
+        /* IPFIX_PPI_TLS_CONTENT_TYPES */
         data_record->record.extended_record.tls_record_types.flag = 255;
         data_record->record.extended_record.tls_record_types.length = BASIC_LIST_HEADER_SIZE + tls_record_count * sizeof(uint8_t);
-        data_record->record.extended_record.tls_record_types.header.field_id = IPFIX_TLS_CONTENT_TYPES;
+        data_record->record.extended_record.tls_record_types.header.field_id = IPFIX_PPI_TLS_CONTENT_TYPES;
         data_record->record.extended_record.tls_record_types.header.element_length = sizeof(uint8_t);
-        data_record->record.extended_record.tls_record_types.header.enterprise_num = 9;
+        data_record->record.extended_record.tls_record_types.header.enterprise_num = CESNET_PEN;
         data_record->record.extended_record.tls_record_types.header.semantic = 3;
         data_record->record.extended_record.tls_record_types.content = tls_record_types;
 
@@ -4391,43 +4391,43 @@ static int ipfix_exp_encode_data_record_extended(ipfix_exporter_data_t *data_rec
              data_record->record.extended_record.tls_sni.length);
     ptr += data_record->record.extended_record.tls_sni.length;
 
-    /* IPFIX_PACKET_LENGTHS */
+    /* IPFIX_PPI_PKT_LENGTHS */
     if (encode_basic_list(ptr, &data_record->record.extended_record.packet_lengths)) {
         return 1;
     }
     ptr += data_record->record.extended_record.packet_lengths.length + 3;
 
-    /* IPFIX_PACKET_DIRECTIONS */
+    /* IPFIX_PPI_PKT_DIRECTIONS */
     if (encode_basic_list(ptr, &data_record->record.extended_record.packet_directions)) {
         return 1;
     }
     ptr += data_record->record.extended_record.packet_directions.length + 3;
 
-    /* IPFIX_PACKET_TIMES */
+    /* IPFIX_PPI_PKT_TIMES */
     if (encode_basic_list(ptr, &data_record->record.extended_record.packet_times)) {
         return 1;
     }
     ptr += data_record->record.extended_record.packet_times.length + 3;
 
-    /* IPFIX_PACKET_FLAGS */
+    /* IPFIX_PPI_PKT_FLAGS */
     if (encode_basic_list(ptr, &data_record->record.extended_record.packet_flags)) {
         return 1;
     }
     ptr += data_record->record.extended_record.packet_flags.length + 3;
 
-    /* IPFIX_TLS_RECORD_LENGTHS */
+    /* IPFIX_PPI_TLS_REC_LENGTHS */
     if (encode_basic_list(ptr, &data_record->record.extended_record.tls_record_lengths)) {
         return 1;
     }
     ptr += data_record->record.extended_record.tls_record_lengths.length + 3;
 
-    /* IPFIX_TLS_RECORD_TIMES */
+    /* IPFIX_PPI_TLS_REC_TIMES */
     if (encode_basic_list(ptr, &data_record->record.extended_record.tls_record_times)) {
         return 1;
     }
     ptr += data_record->record.extended_record.tls_record_times.length + 3;
 
-    /* IPFIX_TLS_CONTENT_TYPES */
+    /* IPFIX_PPI_TLS_CONTENT_TYPES */
     if (encode_basic_list(ptr, &data_record->record.extended_record.tls_record_types)) {
         return 1;
     }


### PR DESCRIPTION
Add support for ipfix export of per-packet information via extended template - `ipfix_export_template=extended`